### PR TITLE
fix: new types for each multicall type

### DIFF
--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -35,6 +35,7 @@ futures.workspace = true
 thiserror.workspace = true
 
 alloy-pubsub = { workspace = true, optional = true }
+alloy-chains.workspace = true
 
 [dev-dependencies]
 alloy-rpc-client = { workspace = true, features = ["pubsub", "ws"] }

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -137,6 +137,24 @@ impl<T, P, D, N: Network> CallBuilder<T, P, D, N> {
     pub fn into_transaction_request(self) -> N::TransactionRequest {
         self.request
     }
+
+    pub fn decoder(&self) -> &D {
+        &self.decoder
+    }
+
+    pub fn take_decoder(self) -> (D, RawCallBuilder<T, P, N>) {
+        (
+            self.decoder,
+            RawCallBuilder {
+                request: self.request,
+                block: self.block,
+                state: self.state,
+                provider: self.provider,
+                decoder: (),
+                transport: PhantomData,
+            },
+        )
+    }
 }
 
 impl<T, P, D, N: Network> AsRef<N::TransactionRequest> for CallBuilder<T, P, D, N> {

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -138,10 +138,12 @@ impl<T, P, D, N: Network> CallBuilder<T, P, D, N> {
         self.request
     }
 
+    /// A refrence to the decoder for this builder
     pub fn decoder(&self) -> &D {
         &self.decoder
     }
 
+    /// Take the decoder from this builder and return a builder without one
     pub fn take_decoder(self) -> (D, RawCallBuilder<T, P, N>) {
         (
             self.decoder,

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -30,6 +30,9 @@ pub use instance::*;
 mod call;
 pub use call::*;
 
+mod multicall;
+pub use multicall::*;
+
 // Not public API.
 // NOTE: please avoid changing the API of this module due to its use in the `sol!` macro.
 #[doc(hidden)]

--- a/crates/contract/src/multicall.rs
+++ b/crates/contract/src/multicall.rs
@@ -1,11 +1,19 @@
+use std::marker::PhantomData;
+
 /// The canon deployed address and chains
 pub mod constants;
-use std::marker::PhantomData;
+mod error;
+
+pub use aggregate::{Aggregate, AggregateRef, OwnedAggregate};
+pub use aggregate3::{Aggregate3, Aggregate3Ref, OwnedAggregate3};
+pub use try_aggregate::{OwnedTryAggregate, TryAggregate, TryAggregateRef};
 
 pub use constants::{MULTICALL_ADDRESS, MULTICALL_SUPPORTED_CHAINS};
 
-mod error;
+#[doc(inline)]
 pub use error::MultiCallError;
+
+use std::sync::Arc;
 
 use alloy_json_abi::Function;
 use alloy_network::{Network, TransactionBuilder};
@@ -63,37 +71,26 @@ sol! {
   }
 }
 
-/// An instance of a dynamically typed MultiCall.
-pub type DynMultiCall<T, P, N> = MultiCall<T, P, Function, N>;
-
-/// An instance of static typed MultiCall.
-/// 
-/// Here we need C: [`alloy_sol_types::SolCall`], which can be easily created by using the [`sol!`] macro.
-pub type SolMultiCall<T, P, C, N> = MultiCall<T, P, PhantomData<C>, N>;
-
 /// The Multicall struct either works with a single type or every return type is dynamic.
-/// 
+///
 /// Multicall is easier to name via the [`SolMultiCall`] or [`DynMultiCall`] type aliases.
 #[derive(Debug)]
-pub struct MultiCall<T, P, D: CallDecoder, N: Network> {
-    instance: IMulticall3::IMulticall3Instance<T, P, N>,
-    calls: Vec<(bool, CallBuilder<T, P, D, N>)>,
-    batch: Option<usize>,
+pub struct MultiCall<T, P, N: Network> {
+    instance: Arc<IMulticall3::IMulticall3Instance<T, P, N>>,
 }
 
-impl<T, P, D, N> MultiCall<T, P, D, N>
+impl<T, P, N> MultiCall<T, P, N>
 where
     T: Transport + Clone,
     P: Provider<T, N>,
-    D: CallDecoder,
     N: Network,
 {
     /// Create a new multicall instance.
-    /// 
+    ///
     /// # Errors
     /// - If the chain_id is not in the list of supported chains.
     pub async fn new(provider: P, address: Option<Address>) -> Result<Self, MultiCallError> {
-        let instance = IMulticall3::IMulticall3Instance::new(
+        let instance = Arc::new(IMulticall3::IMulticall3Instance::new(
             {
                 match address {
                     Some(address) => address,
@@ -107,315 +104,616 @@ where
                 }
             },
             provider,
-        );
+        ));
 
-        Ok(Self { instance, calls: vec![], batch: None })
+        Ok(Self { instance })
     }
 
-    /// Add a call to the multicall instance.
-    pub fn add_call(&mut self, call: CallBuilder<T, P, D, N>, allow_failure: bool) {
-        self.calls.push((allow_failure, call));
+    /// A builder for the aggregate call.
+    pub fn aggregate<'a, D: CallDecoder>(&'a self) -> AggregateRef<'a, T, P, D, N> {
+        AggregateRef { r#ref: &self.instance, calls: vec![], batch: None }
     }
 
-    /// Add multiple calls to the multicall instance.
-    pub fn add_calls<I>(&mut self, calls: I)
-    where
-        I: Iterator<Item = (bool, CallBuilder<T, P, D, N>)>,
-    {
-        self.calls.extend(calls);
+    /// A builder for the try_aggreate call.
+    pub fn try_aggregate<'a, D: CallDecoder>(&'a self) -> TryAggregateRef<'a, T, P, D, N> {
+        TryAggregateRef { r#ref: &self.instance, calls: vec![], batch: None }
     }
 
-    /// Set the batch size 
-    pub fn batch(&mut self, batch: Option<usize>) {
-        self.batch = batch;
+    /// A builder for the aggregate3 call.
+    pub fn aggregate3<'a, D: CallDecoder>(&'a self) -> Aggregate3Ref<'a, T, P, D, N> {
+        Aggregate3Ref { r#ref: &self.instance, calls: vec![], batch: None }
     }
 }
 
-impl<T, P, D, N> MultiCall<T, P, D, N>
-where
-    P: Provider<T, N>,
-    T: Transport + Clone,
-    N: Network,
-    D: CallDecoder,
-{
-    /// Like [Self::aggregate] method but doesnt consume the calls instead
-    pub async fn aggregate_ref(&self) -> Result<Vec<D::CallOutput>, MultiCallError> {
-        let (decoders, requests) = self.parts_ref();
+/// A dyn aggregate call.
+pub type DynAggreagate<T, P, N> = OwnedAggregate<T, P, Function, N>;
 
-        self.aggregate_inner(
-            &decoders,
-            requests
-                .into_iter()
-                .map(|(_, call)| {
-                    call_from_tx_ref::<N>(call)
-                })
-                .collect::<Result<Vec<_>, MultiCallError>>()?,
-        )
-        .await
-    }
+/// A static aggregate call.
+pub type SolAggreagate<T, P, C, N> = OwnedAggregate<T, P, PhantomData<C>, N>;
 
-    /// Calls aggreagte, without cloning any of the calldata
+/// A dyn try aggregate call.
+pub type DynTryAggreagate<T, P, N> = OwnedTryAggregate<T, P, Function, N>;
+
+/// A static try aggregate call.
+pub type SolTryAggreagate<T, P, C, N> = OwnedTryAggregate<T, P, PhantomData<C>, N>;
+
+/// A dyn aggregate3 call.
+pub type DynAggreagate3<T, P, N> = OwnedAggregate3<T, P, Function, N>;
+
+/// A static aggregate3 call.
+pub type SolAggreagate3<T, P, C, N> = OwnedAggregate3<T, P, PhantomData<C>, N>;
+
+mod aggregate {
+    use std::fmt::Debug;
+
+    use super::into_calls::*;
+    use super::*;
+    
+    /// An aggreagte call that owns the refrence to the underlying instance
+    pub type OwnedAggregate<T, P, D, N> =
+        Aggregate<Arc<IMulticall3::IMulticall3Instance<T, P, N>>, T, P, D, N>;
+
+    /// An aggreagte call that doesnt own the refrence to the underlying instance
+    pub type AggregateRef<'a, T, P, D, N> =
+        Aggregate<&'a Arc<IMulticall3::IMulticall3Instance<T, P, N>>, T, P, D, N>;
+
+    /// Represents a call to the aggregate method.
     ///
-    /// Aggreagte will revert on the first failure and ignores any failure mode set on the individual calls
-    pub async fn aggregate(&mut self) -> Result<Vec<D::CallOutput>, MultiCallError> {
-        let (decoders, requests) = self.parts();
-
-        self.aggregate_inner(
-            decoders.iter().collect::<Vec<_>>().as_slice(),
-            requests
-                .into_iter()
-                .map(|(_, call)| {
-                    call_from_tx::<N>(call)
-                })
-                .collect::<Result<Vec<_>, MultiCallError>>()?,
-        )
-        .await
+    /// [`Aggregate`] multicalls will also fail fast.
+    pub struct Aggregate<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        pub(super) r#ref: R,
+        pub(super) calls: Vec<CallBuilder<T, P, D, N>>,
+        pub(super) batch: Option<usize>,
     }
 
-    /// Like [Self::try_aggregate] method but clones the calls
-    pub async fn try_aggregate_ref(
-        &self,
-        require_success: bool,
-    ) -> Result<Vec<D::CallOutput>, MultiCallError> {
-        let (decoders, requests) = self.parts_ref();
+    impl<R, T, P, D, N> Aggregate<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        /// Call the aggregate method, this method will fail fast on any reverts
+        pub async fn call(&self) -> Result<Vec<D::CallOutput>, MultiCallError> {
+            let (decoders, requests) = self.parts_ref();
 
-        self.try_aggregate_inner(
-            require_success,
-            &decoders,
-            requests
-                .into_iter()
-                .map(|(_, call)| {
-                    call_from_tx_ref::<N>(call)
-                })
-                .collect::<Result<Vec<_>, MultiCallError>>()?,
-        )
-        .await
+            self.aggregate_inner(
+                &decoders,
+                requests
+                    .into_iter()
+                    .map(|call| call_from_tx_ref::<N>(call))
+                    .collect::<Result<Vec<_>, MultiCallError>>()?,
+            )
+            .await
+        }
+
+        /// like [Self::call] but will consume the calldata
+        pub async fn call_take(&mut self) -> Result<Vec<D::CallOutput>, MultiCallError> {
+            let (decoders, requests) = self.parts();
+
+            self.aggregate_inner(
+                decoders.iter().collect::<Vec<_>>().as_slice(),
+                requests
+                    .into_iter()
+                    .map(|call| call_from_tx::<N>(call))
+                    .collect::<Result<Vec<_>, MultiCallError>>()?,
+            )
+            .await
+        }
+
+        pub fn set_batch(&mut self, batch: Option<usize>) {
+            self.batch = batch;
+        }
+
+        /// Clear the calls
+        pub fn clear_calls(&mut self) {
+            self.calls.clear();
+        }
+
+        /// Add a call to the multicall
+        pub fn add_call(&mut self, call: CallBuilder<T, P, D, N>) {
+            self.calls.push(call);
+        }
+
+        /// Add multiple calls to the multicall
+        pub fn add_calls<I>(&mut self, calls: I)
+        where
+            I: Iterator<Item = CallBuilder<T, P, D, N>>,
+        {
+            self.calls.extend(calls);
+        }
     }
 
-    /// Calls try_aggregate, without cloning any of the calldata, this method ignores the failure mode set on the individual calls
-    pub async fn try_aggregate(
-        &mut self,
-        require_success: bool,
-    ) -> Result<Vec<D::CallOutput>, MultiCallError> {
-        let (decoders, requests) = self.parts();
+    impl<R, T, P, D, N> Aggregate<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        /// Call the aggregate method, this method will revert on the first failure regardless of what
+        /// you set
+        async fn aggregate_inner(
+            &self,
+            decoders: &[&D],
+            requests: Vec<IMulticall3::Call>,
+        ) -> Result<Vec<D::CallOutput>, MultiCallError> {
+            let mut results;
+            let instance = self.r#ref.as_ref();
 
-        self.try_aggregate_inner(
-            require_success,
-            decoders.iter().collect::<Vec<_>>().as_slice(),
-            requests
+            if let Some(batch) = self.batch {
+                results = Vec::with_capacity(requests.len());
+
+                for chunk in requests.chunks(batch) {
+                    let chunk_results = instance.aggregate(chunk.to_vec()).call().await?;
+
+                    results.extend(chunk_results.returnData);
+                }
+            } else {
+                results = instance.aggregate(requests).call().await?.returnData;
+            }
+
+            results
                 .into_iter()
-                .map(|(_, call)| {
-                    call_from_tx::<N>(call)
+                .zip(decoders.into_iter())
+                .map(|(out, decoder)| decoder.abi_decode_output(out, true))
+                .map(|r| r.map_err(Into::into))
+                .collect()
+        }
+
+        fn parts(&mut self) -> (Vec<D>, Vec<N::TransactionRequest>) {
+            std::mem::take(&mut self.calls)
+                .into_iter()
+                .map(|call| {
+                    let (decoder, req) = call.take_decoder();
+
+                    (decoder, req.into_transaction_request())
                 })
-                .collect::<Result<Vec<_>, MultiCallError>>()?,
-        )
-        .await
+                .unzip()
+        }
+
+        fn parts_ref(&self) -> (Vec<&D>, Vec<&N::TransactionRequest>) {
+            self.calls.iter().map(|call| (call.decoder(), call.as_ref())).unzip()
+        }
     }
 
-    /// Like [Self::aggregate3] method but clones the calls
-    pub async fn aggregate3_ref(&self) -> Result<Vec<D::CallOutput>, MultiCallError> {
-        let (decoders, requests) = self.parts_ref();
+    impl<R, T, P, D, N> Debug for Aggregate<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Aggregate")
+                .field("r#ref type", &std::any::type_name::<R>())
+                .field("calls", &self.calls)
+                .field("batch", &self.batch)
+                .finish()
+        }
+    }
 
-        self.aggregate3_inner(
-            &decoders,
-            requests
+    impl<'a, T, P, D, N> From<AggregateRef<'a, T, P, D, N>> for OwnedAggregate<T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+    {
+        fn from(aggregate: AggregateRef<'a, T, P, D, N>) -> Self {
+            Self { r#ref: aggregate.r#ref.clone(), calls: aggregate.calls, batch: aggregate.batch }
+        }
+    }
+}
+
+mod try_aggregate {
+    use super::into_calls::*;
+    use super::*;
+    use std::fmt::Debug;
+
+    /// An aggreagte call that owns the refrence to the underlying instance
+    pub type OwnedTryAggregate<T, P, D, N> =
+        TryAggregate<Arc<IMulticall3::IMulticall3Instance<T, P, N>>, T, P, D, N>;
+
+    /// An aggreagte call that doesnt own the refrence to the underlying instance
+    pub type TryAggregateRef<'a, T, P, D, N> =
+        TryAggregate<&'a Arc<IMulticall3::IMulticall3Instance<T, P, N>>, T, P, D, N>;
+
+    /// Represents a call to the aggregate method.
+    ///
+    /// [`Aggregate`] multicalls will also fail fast.
+    pub struct TryAggregate<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        pub(super) r#ref: R,
+        pub(super) calls: Vec<CallBuilder<T, P, D, N>>,
+        pub(super) batch: Option<usize>,
+    }
+
+    impl<R, T, P, D, N> Debug for TryAggregate<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("TryAggregate")
+                .field("r#ref type", &std::any::type_name::<R>())
+                .field("calls", &self.calls)
+                .field("batch", &self.batch)
+                .finish()
+        }
+    }
+
+    impl<R, T, P, D, N> TryAggregate<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        /// Call the aggregate method, filtering out any failed calls.
+        pub async fn call(&self, require_success: bool) -> Result<Vec<D::CallOutput>, MultiCallError> {
+            let (decoders, requests) = self.parts_ref();
+
+            self.try_aggregate_inner(
+                require_success,
+                &decoders,
+                requests
+                    .into_iter()
+                    .map(|call| call_from_tx_ref::<N>(call))
+                    .collect::<Result<Vec<_>, MultiCallError>>()?,
+            )
+            .await
+        }
+
+        /// Call the aggregate method, this method will revert on the first failure regardless of what
+        pub async fn call_take(
+            &mut self,
+            require_success: bool,
+        ) -> Result<Vec<D::CallOutput>, MultiCallError> {
+            let (decoders, requests) = self.parts();
+
+            self.try_aggregate_inner(
+                require_success,
+                decoders.iter().collect::<Vec<_>>().as_slice(),
+                requests
+                    .into_iter()
+                    .map(|call| call_from_tx::<N>(call))
+                    .collect::<Result<Vec<_>, MultiCallError>>()?,
+            )
+            .await
+        }
+
+        /// Clear the calls
+        pub fn clear_calls(&mut self) {
+            self.calls.clear();
+        }
+
+        pub fn set_batch(&mut self, batch: Option<usize>) {
+            self.batch = batch;
+        }
+
+        /// Add a call to the multicall
+        pub fn add_call(&mut self, call: CallBuilder<T, P, D, N>) {
+            self.calls.push(call);
+        }
+
+        /// Add multiple calls to the multicall
+        pub fn add_calls<I>(&mut self, calls: I)
+        where
+            I: Iterator<Item = CallBuilder<T, P, D, N>>,
+        {
+            self.calls.extend(calls);
+        }
+    }
+
+    impl<R, T, P, D, N> TryAggregate<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        /// Call the aggregate method, this method will revert on the first failure regardless of what
+        /// you set
+        async fn try_aggregate_inner(
+            &self,
+            require_success: bool,
+            decoders: &[&D],
+            requests: Vec<IMulticall3::Call>,
+        ) -> Result<Vec<D::CallOutput>, MultiCallError> {
+            let mut results;
+            let instance = self.r#ref.as_ref();
+
+            if let Some(batch) = self.batch {
+                results = Vec::with_capacity(requests.len());
+
+                for chunk in requests.chunks(batch) {
+                    let chunk_results =
+                        instance.tryAggregate(require_success, chunk.to_vec()).call().await?;
+
+                    results.extend(chunk_results.returnData);
+                }
+            } else {
+                results = instance.tryAggregate(require_success, requests).call().await?.returnData;
+            }
+
+            results
+                .into_iter()
+                .zip(decoders.into_iter())
+                .filter_map(|(out, decoder)| {
+                    if out.success {
+                        Some(decoder.abi_decode_output(out.returnData, true))
+                    } else {
+                        None
+                    }
+                })
+                .map(|r| r.map_err(Into::into))
+                .collect()
+        }
+
+        fn parts(&mut self) -> (Vec<D>, Vec<N::TransactionRequest>) {
+            std::mem::take(&mut self.calls)
+                .into_iter()
+                .map(|call| {
+                    let (decoder, req) = call.take_decoder();
+
+                    (decoder, req.into_transaction_request())
+                })
+                .unzip()
+        }
+
+        fn parts_ref(&self) -> (Vec<&D>, Vec<&N::TransactionRequest>) {
+            self.calls.iter().map(|call| (call.decoder(), call.as_ref())).unzip()
+        }
+    }
+}
+
+mod aggregate3 {
+    use super::into_calls::*;
+    use super::*;
+    use std::fmt::Debug;
+
+    /// An aggreagte call that owns the refrence to the underlying instance
+    pub type OwnedAggregate3<T, P, D, N> =
+        Aggregate3<Arc<IMulticall3::IMulticall3Instance<T, P, N>>, T, P, D, N>;
+
+    /// An aggreagte call that doesnt own the refrence to the underlying instance
+    pub type Aggregate3Ref<'a, T, P, D, N> =
+        Aggregate3<&'a Arc<IMulticall3::IMulticall3Instance<T, P, N>>, T, P, D, N>;
+
+    /// Represents a call to the aggregate method.
+    ///
+    /// [`Aggregate`] multicalls will also fail fast.
+    pub struct Aggregate3<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        pub(super) r#ref: R,
+        pub(super) calls: Vec<(bool, CallBuilder<T, P, D, N>)>,
+        pub(super) batch: Option<usize>,
+    }
+
+    impl<R, T, P, D, N> Debug for Aggregate3<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("TryAggregate")
+                .field("r#ref type", &std::any::type_name::<R>())
+                .field("calls", &self.calls)
+                .field("batch", &self.batch)
+                .finish()
+        }
+    }
+
+    impl<R, T, P, D, N> Aggregate3<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        /// Call the aggregate3 method, filtering out any failed calls.
+        pub async fn call(&self) -> Result<Vec<D::CallOutput>, MultiCallError> {
+            let (decoders, requests) = self.parts_ref();
+
+            self.aggregate3_inner(
+                &decoders,
+                requests
+                    .into_iter()
+                    .map(|(allow_failure, call)| call3_from_tx_ref::<N>(call, allow_failure))
+                    .collect::<Result<Vec<_>, MultiCallError>>()?,
+            )
+            .await
+        }
+
+        /// like [Self::call] but will consume the calldata
+        pub async fn call_take(&mut self) -> Result<Vec<D::CallOutput>, MultiCallError> {
+            let (decoders, requests) = self.parts();
+
+            self.aggregate3_inner(
+                decoders.iter().collect::<Vec<_>>().as_slice(),
+                requests
+                    .into_iter()
+                    .map(|(allow_failure, call)| call3_from_tx::<N>(call, allow_failure))
+                    .collect::<Result<Vec<_>, MultiCallError>>()?,
+            )
+            .await
+        }
+
+        /// Clear the calls
+        pub fn clear_calls(&mut self) {
+            self.calls.clear();
+        }
+
+        pub fn set_batch(&mut self, batch: Option<usize>) {
+            self.batch = batch;
+        }
+
+        /// Add a call to the multicall
+        pub fn add_call(&mut self, allow_failure: bool, call: CallBuilder<T, P, D, N>) {
+            self.calls.push((allow_failure, call));
+        }
+
+        /// Add multiple calls to the multicall
+        pub fn add_calls<I>(&mut self, calls: I)
+        where
+            I: Iterator<Item = (bool, CallBuilder<T, P, D, N>)>,
+        {
+            self.calls.extend(calls);
+        }
+    }
+
+    impl<R, T, P, D, N> Aggregate3<R, T, P, D, N>
+    where
+        T: Transport + Clone,
+        P: Provider<T, N>,
+        D: CallDecoder,
+        N: Network,
+        R: AsRef<IMulticall3::IMulticall3Instance<T, P, N>>,
+    {
+        /// Call the aggregate method, this method will revert on the first failure regardless of what
+        /// you set
+        async fn aggregate3_inner(
+            &self,
+            decoders: &[&D],
+            requests: Vec<IMulticall3::Call3>,
+        ) -> Result<Vec<D::CallOutput>, MultiCallError> {
+            let mut results;
+            let instance = self.r#ref.as_ref();
+
+            if let Some(batch) = self.batch {
+                results = Vec::with_capacity(requests.len());
+
+                for chunk in requests.chunks(batch) {
+                    let chunk_results = instance.aggregate3(chunk.to_vec()).call().await?;
+
+                    results.extend(chunk_results.returnData);
+                }
+            } else {
+                results = instance.aggregate3(requests).call().await?.returnData;
+            }
+
+            results
+                .into_iter()
+                .zip(decoders.into_iter())
+                .filter_map(|(r, d)| {
+                    if r.success {
+                        Some(d.abi_decode_output(r.returnData, true))
+                    } else {
+                        None
+                    }
+                })
+                .map(|r| r.map_err(Into::into))
+                .collect()
+        }
+
+        fn parts(&mut self) -> (Vec<D>, Vec<(bool, N::TransactionRequest)>) {
+            std::mem::take(&mut self.calls)
                 .into_iter()
                 .map(|(allow_failure, call)| {
-                    call3_from_tx_ref::<N>(call, allow_failure)
+                    let (decoder, req) = call.take_decoder();
+
+                    (decoder, (allow_failure, req.into_transaction_request()))
                 })
-                .collect::<Result<Vec<_>, MultiCallError>>()?,
-        )
-        .await
-    }
-
-    /// Calls aggregate3, without cloning any of the calldata
-    pub async fn aggregate3(&mut self) -> Result<Vec<D::CallOutput>, MultiCallError> {
-        let (decoders, requests) = self.parts();
-
-        self.aggregate3_inner(
-            decoders.iter().collect::<Vec<_>>().as_slice(),
-            requests
-                .into_iter()
-                .map(|(allow_failure, call)| {
-                    call3_from_tx::<N>(call, allow_failure)
-                })
-                .collect::<Result<Vec<_>, MultiCallError>>()?,
-        )
-        .await
-    }
-
-    /// Cleas the calls if any
-    pub fn clear_calls(&mut self) {
-        self.calls.clear();
-    }
-}
-
-impl<T, P, D, N> MultiCall<T, P, D, N>
-where
-    P: Provider<T, N>,
-    T: Transport + Clone,
-    N: Network,
-    D: CallDecoder,
-{
-    /// Call the aggregate method, this method will revert on the first failure regardless of what
-    /// you set
-    async fn aggregate_inner(
-        &self,
-        decoders: &[&D],
-        requests: Vec<IMulticall3::Call>,
-    ) -> Result<Vec<D::CallOutput>, MultiCallError> {
-        let mut results;
-
-        if let Some(batch) = self.batch {
-            results = Vec::with_capacity(requests.len());
-
-            for chunk in requests.chunks(batch) {
-                let chunk_results = self.instance.aggregate(chunk.to_vec()).call().await?;
-
-                results.extend(chunk_results.returnData);
-            }
-        } else {
-            results = self.instance.aggregate(requests).call().await?.returnData;
+                .unzip()
         }
 
-        results
-            .into_iter()
-            .zip(decoders.into_iter())
-            .map(|(out, decoder)| decoder.abi_decode_output(out, true))
-            .map(|r| r.map_err(Into::into))
-            .collect()
-    }
-
-    /// Try to aggregate the calls, this method ignores the failure mode set on the individual calls
-    async fn try_aggregate_inner(
-        &self,
-        require_success: bool,
-        decoders: &[&D],
-        requests: Vec<IMulticall3::Call>,
-    ) -> Result<Vec<D::CallOutput>, MultiCallError> {
-        let mut results;
-
-        if let Some(batch) = self.batch {
-            results = Vec::with_capacity(requests.len());
-
-            for chunk in requests.chunks(batch) {
-                let chunk_results = self.instance.tryAggregate(require_success, chunk.to_vec()).call().await?;
-
-                results.extend(chunk_results.returnData);
-            }
-        } else {
-            results = self.instance.tryAggregate(require_success, requests).call().await?.returnData;
+        fn parts_ref(&self) -> (Vec<&D>, Vec<(bool, &N::TransactionRequest)>) {
+            self.calls
+                .iter()
+                .map(|(allow_failure, call)| (call.decoder(), (*allow_failure, call.as_ref())))
+                .unzip()
         }
-
-        results
-            .into_iter()
-            .zip(decoders.into_iter())
-            .filter_map(|(out, decoder)| {
-                if out.success {
-                    Some(decoder.abi_decode_output(out.returnData, true))
-                } else {
-                    None
-                }
-            })
-            .map(|r| r.map_err(Into::into))
-            .collect()
-    }
-
-    /// Call the aggregate3 method, this method utilizes the allow_failure flag on the individual
-    /// calls
-    async fn aggregate3_inner(
-        &self,
-        decoders: &[&D],
-        requests: Vec<IMulticall3::Call3>,
-    ) -> Result<Vec<D::CallOutput>, MultiCallError> {
-        let mut results;
-
-        if let Some(batch) = self.batch {
-            results = Vec::with_capacity(requests.len());
-
-            for chunk in requests.chunks(batch) {
-                let chunk_results = self.instance.aggregate3(chunk.to_vec()).call().await?;
-
-                results.extend(chunk_results.returnData);
-            }
-        } else {
-            results = self.instance.aggregate3(requests).call().await?.returnData;
-        }
-
-        results
-            .into_iter()
-            .zip(decoders.into_iter())
-            .filter_map(|(r, d)| {
-                if r.success {
-                    Some(d.abi_decode_output(r.returnData, true))
-                } else {
-                    None
-                }
-            })
-            .map(|r| r.map_err(Into::into))
-            .collect()
-    }
-
-    fn parts(&mut self) -> (Vec<D>, Vec<(bool, N::TransactionRequest)>) {
-        std::mem::take(&mut self.calls)
-            .into_iter()
-            .map(|(allow_failure, call)| {
-                let (decoder, req) = call.take_decoder();
-
-                (decoder, (allow_failure, req.into_transaction_request()))
-            })
-            .unzip()
-    }
-
-    fn parts_ref(&self) -> (Vec<&D>, Vec<(bool, &N::TransactionRequest)>) {
-        self.calls
-            .iter()
-            .map(|(allow_failure, call)| (call.decoder(), (*allow_failure, call.as_ref())))
-            .unzip()
     }
 }
 
-fn call3_from_tx<N>(tx: N::TransactionRequest, allow_failure: bool) -> Result<IMulticall3::Call3, MultiCallError>
-where
-    N: Network,
-{
-    Ok(IMulticall3::Call3 {
-        target: tx.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
-        allowFailure: allow_failure,
-        callData: tx.into_input().unwrap_or_default(),
-    })
-}
+mod into_calls {
+    use super::{IMulticall3, MultiCallError, Network, TransactionBuilder};
 
-fn call3_from_tx_ref<N>(
-    tx: &N::TransactionRequest,
-    allow_failure: bool,
-) -> Result<IMulticall3::Call3, MultiCallError>
-where
-    N: Network,
-{
-    Ok(IMulticall3::Call3 {
-        target: tx.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
-        allowFailure: allow_failure,
-        callData: tx.input().cloned().unwrap_or_default(),
-    })
-}
+    #[inline]
+    pub(super) fn call3_from_tx<N>(
+        tx: N::TransactionRequest,
+        allow_failure: bool,
+    ) -> Result<IMulticall3::Call3, MultiCallError>
+    where
+        N: Network,
+    {
+        Ok(IMulticall3::Call3 {
+            target: tx.to().ok_or(MultiCallError::MissingTargetAddress)?,
+            allowFailure: allow_failure,
+            callData: tx.into_input().unwrap_or_default(),
+        })
+    }
 
-fn call_from_tx<N>(tx: N::TransactionRequest) -> Result<IMulticall3::Call, MultiCallError>
-where
-    N: Network,
-{
-    Ok(IMulticall3::Call {
-        target: tx.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
-        callData: tx.into_input().unwrap_or_default(),
-    })
-}
+    #[inline]
+    pub(super) fn call3_from_tx_ref<N>(
+        tx: &N::TransactionRequest,
+        allow_failure: bool,
+    ) -> Result<IMulticall3::Call3, MultiCallError>
+    where
+        N: Network,
+    {
+        Ok(IMulticall3::Call3 {
+            target: tx.to().ok_or(MultiCallError::MissingTargetAddress)?,
+            allowFailure: allow_failure,
+            callData: tx.input().cloned().unwrap_or_default(),
+        })
+    }
 
-fn call_from_tx_ref<N>(tx: &N::TransactionRequest) -> Result<IMulticall3::Call, MultiCallError>
-where
-    N: Network,
-{
-    Ok(IMulticall3::Call {
-        target: tx.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
-        callData: tx.input().cloned().unwrap_or_default(),
-    })
+    #[inline]
+    pub(super) fn call_from_tx<N>(
+        tx: N::TransactionRequest,
+    ) -> Result<IMulticall3::Call, MultiCallError>
+    where
+        N: Network,
+    {
+        Ok(IMulticall3::Call {
+            target: tx.to().ok_or(MultiCallError::MissingTargetAddress)?,
+            callData: tx.into_input().unwrap_or_default(),
+        })
+    }
+
+    #[inline]
+    pub(super) fn call_from_tx_ref<N>(
+        tx: &N::TransactionRequest,
+    ) -> Result<IMulticall3::Call, MultiCallError>
+    where
+        N: Network,
+    {
+        Ok(IMulticall3::Call {
+            target: tx.to().ok_or(MultiCallError::MissingTargetAddress)?,
+            callData: tx.input().cloned().unwrap_or_default(),
+        })
+    }
 }

--- a/crates/contract/src/multicall.rs
+++ b/crates/contract/src/multicall.rs
@@ -1,0 +1,331 @@
+#![allow(missing_docs)]
+
+pub mod constants;
+pub use constants::{MULTICALL_ADDRESS, MULTICALL_SUPPORTED_CHAINS};
+
+mod error;
+pub use error::MultiCallError;
+
+use alloy_json_abi::Function;
+use alloy_network::{Network, TransactionBuilder};
+use alloy_primitives::{Address, Bytes};
+use alloy_provider::Provider;
+use alloy_sol_types::sol;
+use alloy_transport::Transport;
+
+use crate::{CallBuilder, CallDecoder};
+
+sol! {
+    #![sol(alloy_contract = crate)]
+    #[derive(Debug)]
+    #[sol(rpc, abi)]
+    /// Module containing types and functions of the Multicall3 contract.
+    interface IMulticall3 {
+        struct Call {
+            address target;
+            bytes callData;
+        }
+
+        struct Call3 {
+            address target;
+            bool allowFailure;
+            bytes callData;
+        }
+
+        struct Call3Value {
+            address target;
+            bool allowFailure;
+            uint256 value;
+            bytes callData;
+        }
+
+        struct Result {
+            bool success;
+            bytes returnData;
+        }
+
+        function aggregate(Call[] calldata calls)
+            external
+            payable
+            returns (uint256 blockNumber, bytes[] memory returnData);
+
+        function aggregate3(Call3[] calldata calls) external payable returns (Result[] memory returnData);
+
+        function tryAggregate(bool requireSuccess, Call[] calldata calls)
+            external
+            payable
+            returns (Result[] memory returnData);
+  }
+}
+
+pub type DynMultiCall<T, P, N> = MultiCall<T, P, Function, N>;
+
+#[derive(Debug)]
+pub struct MultiCall<T, P, D: CallDecoder, N: Network> {
+    instance: IMulticall3::IMulticall3Instance<T, P, N>,
+    calls: Vec<(bool, CallBuilder<T, P, D, N>)>,
+}
+
+impl<T, P, D, N> MultiCall<T, P, D, N>
+where
+    T: Transport + Clone,
+    P: Provider<T, N>,
+    D: CallDecoder,
+    N: Network,
+{
+    pub async fn new(provider: P, address: Option<Address>) -> Result<Self, MultiCallError> {
+        let instance = IMulticall3::IMulticall3Instance::new(
+            {
+                match address {
+                    Some(address) => address,
+                    None => {
+                        if !MULTICALL_SUPPORTED_CHAINS.contains(&provider.get_chain_id().await?) {
+                            MULTICALL_ADDRESS
+                        } else {
+                            return Err(error::MultiCallError::MissingTargetAddress);
+                        }
+                    }
+                }
+            },
+            provider,
+        );
+
+        Ok(Self { instance, calls: vec![] })
+    }
+
+    pub fn add_call<'a>(&mut self, call: CallBuilder<T, P, D, N>, allow_failure: bool) {
+        self.calls.push((allow_failure, call));
+    }
+
+    pub fn add_calls<I>(&mut self, calls: I)
+    where
+        I: Iterator<Item = (bool, CallBuilder<T, P, D, N>)>,
+    {
+        self.calls.extend(calls);
+    }
+}
+
+impl<T, P, D, N> MultiCall<T, P, D, N>
+where
+    P: Provider<T, N>,
+    T: Transport + Clone,
+    N: Network,
+    D: CallDecoder,
+{
+    /// Like [Self::aggregate] method but doesnt consume the calls instead
+    pub async fn aggregate_ref(&self) -> Result<Vec<D::CallOutput>, MultiCallError> {
+        let (decoders, requests) = self.parts_ref();
+
+        self.aggregate_inner(
+            &decoders,
+            requests
+                .into_iter()
+                .map(|(_, call)| {
+                    Ok(IMulticall3::Call {
+                        target: call.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
+                        callData: call.input().cloned().unwrap_or_default(),
+                    })
+                })
+                .collect::<Result<Vec<_>, MultiCallError>>()?,
+        )
+        .await
+    }
+
+    /// Calls aggreagte, without cloning any of the calldata
+    /// 
+    /// Aggreagte will revert on the first failure and ignores any failure mode set on the individual calls
+    pub async fn aggregate(&mut self) -> Result<Vec<D::CallOutput>, MultiCallError> {
+        let (decoders, requests) = self.parts();
+
+        self.aggregate_inner(
+            decoders.iter().collect::<Vec<_>>().as_slice(),
+            requests
+                .into_iter()
+                .map(|(_, call)| {
+                    Ok(IMulticall3::Call {
+                        target: call.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
+                        callData: call.into_input().unwrap_or_default(),
+                    })
+                })
+                .collect::<Result<Vec<_>, MultiCallError>>()?,
+        )
+        .await
+    }
+
+    //// Like [Self::try_aggregate] method but clones the calls
+    pub async fn try_aggregate_ref(&self, require_success: bool) -> Result<Vec<D::CallOutput>, MultiCallError> {
+        let (decoders, requests) = self.parts_ref();
+
+        self.try_aggregate_inner(
+            require_success,
+            &decoders,
+            requests
+                .into_iter()
+                .map(|(_, call)| {
+                    Ok(IMulticall3::Call {
+                        target: call.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
+                        callData: call.input().cloned().unwrap_or_default(),
+                    })
+                })
+                .collect::<Result<Vec<_>, MultiCallError>>()?,
+        )
+        .await
+    }
+
+    /// Calls try_aggregate, without cloning any of the calldata, this method ignores the failure mode set on the individual calls
+    pub async fn try_aggregate(&mut self, require_success: bool) -> Result<Vec<D::CallOutput>, MultiCallError> {
+        let (decoders, requests) = self.parts();
+
+        self.try_aggregate_inner(
+            require_success,
+            decoders.iter().collect::<Vec<_>>().as_slice(),
+            requests
+                .into_iter()
+                .map(|(_, call)| {
+                    Ok(IMulticall3::Call {
+                        target: call.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
+                        callData: call.into_input().unwrap_or_default(),
+                    })
+                })
+                .collect::<Result<Vec<_>, MultiCallError>>()?,
+        )
+        .await
+    }
+
+    /// Like [Self::aggregate3] method but clones the calls
+    pub async fn aggregate3_ref(&self) -> Result<Vec<D::CallOutput>, MultiCallError> {
+        let (decoders, requests) = self.parts_ref();
+
+        self.aggregate3_inner(
+            &decoders,
+            requests
+                .into_iter()
+                .map(|(allow_failure, call)| {
+                    Ok(IMulticall3::Call3 {
+                        target: call.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
+                        allowFailure: allow_failure,
+                        callData: call.input().cloned().unwrap_or_default(),
+                    })
+                })
+                .collect::<Result<Vec<_>, MultiCallError>>()?,
+        )
+        .await
+    }
+
+    /// Calls aggregate3, without cloning any of the calldata
+    pub async fn aggregate3(&mut self) -> Result<Vec<D::CallOutput>, MultiCallError> {
+        let (decoders, requests) = self.parts();
+
+        self.aggregate3_inner(
+            decoders.iter().collect::<Vec<_>>().as_slice(),
+            requests
+                .into_iter()
+                .map(|(allow_failure, call)| {
+                    Ok(IMulticall3::Call3 {
+                        target: call.to().ok_or(error::MultiCallError::MissingTargetAddress)?,
+                        allowFailure: allow_failure,
+                        callData: call.into_input().unwrap_or_default(),
+                    })
+                })
+                .collect::<Result<Vec<_>, MultiCallError>>()?,
+        )
+        .await
+    }
+
+    pub fn clear_calls(&mut self) {
+        self.calls.clear();
+    }
+}
+
+impl<T, P, D, N> MultiCall<T, P, D, N>
+where
+    P: Provider<T, N>,
+    T: Transport + Clone,
+    N: Network,
+    D: CallDecoder,
+{
+    /// Call the aggregate method, this method will revert on the first failure regardless of what
+    /// you set
+    async fn aggregate_inner(
+        &self,
+        decoders: &[&D],
+        requests: Vec<IMulticall3::Call>,
+    ) -> Result<Vec<D::CallOutput>, MultiCallError> {
+        let results = self.instance.aggregate(requests).call().await?;
+
+        // we dont need to check for success here since this method will revert on the first failure
+        results
+            .returnData
+            .into_iter()
+            .zip(decoders.into_iter())
+            .map(|(out, decoder)| decoder.abi_decode_output(out, true))
+            .map(|r| r.map_err(Into::into))
+            .collect()
+    }
+
+    /// Try to aggregate the calls, this method ignores the failure mode set on the individual calls
+    pub async fn try_aggregate_inner(
+        &self,
+        require_success: bool,
+        decoders: &[&D],
+        requests: Vec<IMulticall3::Call>,
+    ) -> Result<Vec<D::CallOutput>, MultiCallError> {
+        let results = self.instance.tryAggregate(require_success, requests).call().await?;
+
+        results
+            .returnData
+            .into_iter()
+            .zip(decoders.into_iter())
+            .filter_map(|(out, decoder)| {
+                if out.success {
+                    Some(decoder.abi_decode_output(out.returnData, true))
+                } else {
+                    None
+                }
+            })
+            .map(|r| r.map_err(Into::into))
+            .collect()
+    }
+
+    /// Call the aggregate3 method, this method utilizes the allow_failure flag on the individual
+    /// calls
+    pub async fn aggregate3_inner(
+        &self,
+        decoders: &[&D],
+        requests: Vec<IMulticall3::Call3>,
+    ) -> Result<Vec<D::CallOutput>, MultiCallError> {
+        let results = self.instance.aggregate3(requests).call().await?;
+
+        results
+            .returnData
+            .into_iter()
+            .zip(decoders.into_iter())
+            .filter_map(|(r, d)| {
+                if r.success {
+                    Some(d.abi_decode_output(r.returnData, true))
+                } else {
+                    None
+                }
+            })
+            .map(|r| r.map_err(Into::into))
+            .collect()
+    }
+
+    fn parts(&mut self) -> (Vec<D>, Vec<(bool, N::TransactionRequest)>) {
+        std::mem::take(&mut self.calls)
+            .into_iter()
+            .map(|(allow_failure, call)| {
+                let (decoder, req) = call.take_decoder();
+
+                (decoder, (allow_failure, req.into_transaction_request()))
+            })
+            .unzip()
+    }
+
+    fn parts_ref(&self) -> (Vec<&D>, Vec<(bool, &N::TransactionRequest)>) {
+        self.calls
+            .iter()
+            .map(|(allow_failure, call)| (call.decoder(), (*allow_failure, call.as_ref())))
+            .unzip()
+    }
+}

--- a/crates/contract/src/multicall.rs
+++ b/crates/contract/src/multicall.rs
@@ -20,7 +20,7 @@ sol! {
     #![sol(alloy_contract = crate)]
     #[allow(missing_docs)]
     #[derive(Debug)]
-    #[sol(rpc, abi)]
+    #[sol(rpc)]
     /// Module containing types and functions of the Multicall3 contract.
     interface IMulticall3 {
         struct Call {
@@ -67,9 +67,13 @@ sol! {
 pub type DynMultiCall<T, P, N> = MultiCall<T, P, Function, N>;
 
 /// An instance of static typed MultiCall.
+/// 
+/// Here we need C: [`alloy_sol_types::SolCall`], which can be easily created by using the [`sol!`] macro.
 pub type SolMultiCall<T, P, C, N> = MultiCall<T, P, PhantomData<C>, N>;
 
-/// The MultiCall struct is used to aggregate multiple calls into a single call.
+/// The Multicall struct either works with a single type or every return type is dynamic.
+/// 
+/// Multicall is easier to name via the [`SolMultiCall`] or [`DynMultiCall`] type aliases.
 #[derive(Debug)]
 pub struct MultiCall<T, P, D: CallDecoder, N: Network> {
     instance: IMulticall3::IMulticall3Instance<T, P, N>,
@@ -283,7 +287,7 @@ where
     }
 
     /// Try to aggregate the calls, this method ignores the failure mode set on the individual calls
-    pub async fn try_aggregate_inner(
+    async fn try_aggregate_inner(
         &self,
         require_success: bool,
         decoders: &[&D],
@@ -319,7 +323,7 @@ where
 
     /// Call the aggregate3 method, this method utilizes the allow_failure flag on the individual
     /// calls
-    pub async fn aggregate3_inner(
+    async fn aggregate3_inner(
         &self,
         decoders: &[&D],
         requests: Vec<IMulticall3::Call3>,

--- a/crates/contract/src/multicall/constants.rs
+++ b/crates/contract/src/multicall/constants.rs
@@ -1,0 +1,111 @@
+use alloy_chains::NamedChain;
+use alloy_primitives::{address, Address};
+
+/// The Multicall3 contract address that is deployed to each [`MULTICALL_SUPPORTED_CHAINS`]:
+/// [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://etherscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11)
+pub const MULTICALL_ADDRESS: Address = address!("cA11bde05977b3631167028862bE2a173976CA11");
+
+/// The chain IDs that Multicall3 has been deployed to at [`MULTICALL_ADDRESS`].
+///
+/// Taken from <https://www.multicall3.com/deployments>
+pub const MULTICALL_SUPPORTED_CHAINS: &[u64] = {
+    use NamedChain::*;
+    &[
+        Mainnet as u64,                  // Mainnet
+        Kovan as u64,                    // Kovan
+        Rinkeby as u64,                  // Rinkeby
+        Goerli as u64,                   // Görli
+        Ropsten as u64,                  // Ropsten
+        Sepolia as u64,                  // Sepolia
+        Holesky as u64,                  // Holesky
+        Optimism as u64,                 // Optimism
+        OptimismKovan as u64,            // Optimism Kovan
+        OptimismGoerli as u64,           // Optimism Görli
+        OptimismSepolia as u64,          // Optimism Sepolia
+        Arbitrum as u64,                 // Arbitrum
+        ArbitrumNova as u64,             // Arbitrum Nova
+        ArbitrumGoerli as u64,           // Arbitrum Görli
+        ArbitrumSepolia as u64,          // Arbitrum Sepolia
+        ArbitrumTestnet as u64,          // Arbitrum Rinkeby
+        23011913,                        // Stylus Testnet
+        Polygon as u64,                  // Polygon
+        PolygonMumbai as u64,            // Polygon Mumbai
+        PolygonZkEvm as u64,             // Polygon zkEVM
+        PolygonZkEvmTestnet as u64,      // Polygon zkEVM Testnet
+        Gnosis as u64,                   // Gnosis (xDai) Chain
+        Chiado as u64,                   // Gnosis Chain Testnet
+        Avalanche as u64,                // Avalanche
+        AvalancheFuji as u64,            // Avalanche Fuji
+        FantomTestnet as u64,            // Fantom Testnet
+        Fantom as u64,                   // Fantom Opera
+        64240,                           // Fantom Sonic
+        BinanceSmartChain as u64,        // BNB Smart Chain
+        BinanceSmartChainTestnet as u64, // BNB Smart Chain Testnet
+        5611,                            // opBNB Testnet
+        204,                             // opBNB
+        Moonbeam as u64,                 // Moonbeam
+        Moonriver as u64,                // Moonriver
+        Moonbase as u64,                 // Moonbase Alpha Testnet
+        11297108109,                     // Palm
+        11297108099,                     // Palm Testnet
+        1666600000,                      // Harmony
+        Cronos as u64,                   // Cronos
+        CronosTestnet as u64,            // Cronos Testnet
+        122,                             // Fuse
+        14,                              // Flare Mainnet
+        19,                              // Songbird Canary Network
+        16,                              // Coston Testnet
+        114,                             // Coston2 Testnet
+        Boba as u64,                     // Boba
+        Aurora as u64,                   // Aurora
+        592,                             // Astar
+        6038361,                         // Astar zKyoto Testnet
+        3776,                            // Astar zkEVM
+        66,                              // OKC
+        128,                             // Heco Chain
+        Metis as u64,                    // Metis
+        599,                             // Metis Goerli
+        Rsk as u64,                      // Rsk
+        31,                              // Rsk Testnet
+        Evmos as u64,                    // Evmos
+        EvmosTestnet as u64,             // Evmos Testnet
+        108,                             // Thundercore
+        18,                              // Thundercore Testnet
+        Oasis as u64,                    // Oasis
+        23294,                           // Oasis Sapphire
+        Celo as u64,                     // Celo
+        CeloAlfajores as u64,            // Celo Alfajores Testnet
+        71402,                           // Godwoken
+        71401,                           // Godwoken Testnet
+        8217,                            // Klaytn
+        1001,                            // Klaytn Testnet (Baobab)
+        2001,                            // Milkomeda
+        321,                             // KCC
+        106,                             // Velas
+        40,                              // Telos
+        1234,                            // Step Network
+        Canto as u64,                    // Canto
+        CantoTestnet as u64,             // Canto Testnet
+        4689,                            // Iotex
+        32520,                           // Bitgert
+        2222,                            // Kava
+        5003,                            // Mantle Sepolia
+        MantleTestnet as u64,            // Mantle Testnet
+        Mantle as u64,                   // Mantle
+        8082,                            // Shardeum Sphinx
+        BaseGoerli as u64,               // Base Görli
+        BaseSepolia as u64,              // Base Sepolia
+        Base as u64,                     // Base
+        2358,                            // Kroma Testnet (Sepolia)
+        1130,                            // DeFiChain EVM Mainnet
+        1131,                            // DeFiChain EVM Testnet
+        335,                             // DFK Chain Testnet
+        53935,                           // DFK Chain
+        // TODO - add remaining chains
+        1131,                // DeFiChain EVM Testnet
+        BlastSepolia as u64, // Blast Sepolia
+        Mode as u64,         // Mode Mainnet
+        #[cfg(test)]
+        31337, // Anvil
+    ]
+};

--- a/crates/contract/src/multicall/error.rs
+++ b/crates/contract/src/multicall/error.rs
@@ -1,0 +1,22 @@
+use alloy_transport::TransportError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum MultiCallError {
+    #[error("A call with no target address was attempted to be added to the multicall")]
+    MissingTargetAddress,
+
+    #[error("The multicall contract is not deployed on the current chain")]
+    ChainNotSupported,
+
+    #[error("Decoding Failed: {0}")]
+    DecoderError(#[from] alloy_sol_types::Error),
+
+    #[error("Contract Error: {0}")]
+    ContractError(#[from] crate::Error),
+
+    #[error("Transport Error: {0}")]
+    TransportError(#[from] TransportError),
+
+    #[error("Tried to add no calls")]
+    NoCalls,
+}

--- a/crates/contract/src/multicall/error.rs
+++ b/crates/contract/src/multicall/error.rs
@@ -1,6 +1,9 @@
 use alloy_transport::TransportError;
 
+
 #[derive(Debug, thiserror::Error)]
+/// Errors that can occur when interacting with the Multicall contract
+#[allow(missing_docs)]
 pub enum MultiCallError {
     #[error("A call with no target address was attempted to be added to the multicall")]
     MissingTargetAddress,
@@ -16,7 +19,4 @@ pub enum MultiCallError {
 
     #[error("Transport Error: {0}")]
     TransportError(#[from] TransportError),
-
-    #[error("Tried to add no calls")]
-    NoCalls,
 }

--- a/crates/contract/src/multicall/error.rs
+++ b/crates/contract/src/multicall/error.rs
@@ -14,9 +14,9 @@ pub enum MultiCallError {
     #[error("Decoding Failed: {0}")]
     DecoderError(#[from] alloy_sol_types::Error),
 
-    #[error("Contract Error: {0}")]
+    #[error(transparent)]
     ContractError(#[from] crate::Error),
 
-    #[error("Transport Error: {0}")]
+    #[error(transparent)]
     TransportError(#[from] TransportError),
 }

--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -30,6 +30,10 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
         self.deref().input()
     }
 
+    fn into_input(self) -> Option<Bytes> {
+        self.inner.into_input()
+    }
+
     fn set_input<T: Into<Bytes>>(&mut self, input: T) {
         self.deref_mut().set_input(input);
     }

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -27,6 +27,10 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
         self.input.input()
     }
 
+    fn into_input(self) -> Option<Bytes> {
+        self.input.into_input()
+    }
+
     fn set_input<T: Into<Bytes>>(&mut self, input: T) {
         self.input.input = Some(input.into());
     }

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -93,6 +93,9 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
     /// Get the input data for the transaction.
     fn input(&self) -> Option<&Bytes>;
 
+    /// Take the input data for the transaction.
+    fn into_input(self) -> Option<Bytes>;
+
     /// Set the input data for the transaction.
     fn set_input<T: Into<Bytes>>(&mut self, input: T);
 


### PR DESCRIPTION
## Motivation

Users dont always have mutable access to the multicall instance, and we dont always want to clone  everything

## Solution

Introduce a new type for each Multicall Type (`aggregate`, `try_aggregate`. `aggreagte3`) that holds an `R: AsRef<MultiCall>`

When a users creates a mutlicall for the first (they name this and store it somewhere) we put it in an arc

when a users wants to make a multicall we store an &Arc<_> to avoid cleanup and stuff, users can mutate this wrapper that holds the ref to add calls and batching

you can execute the call from here, or convert it into an "Owned" version of the call (thru the From trait) which clones the arc and you can name the batch of calls without lifetime

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
